### PR TITLE
Allow loading systems not listed by `ql:system-list`

### DIFF
--- a/sly-quicklisp.el
+++ b/sly-quicklisp.el
@@ -51,7 +51,7 @@ in `sly-editing-mode-hook', i.e. lisp files."
                               (sly-eval
                                '(slynk-quicklisp:available-system-names))
                               nil
-                              t)))
+                              nil)))
   (sly-eval-async `(slynk-quicklisp:quickload ,system)
     (lambda (retval)
       (setq sly-quicklisp--enabled-dists retval)


### PR DESCRIPTION
Hello.
This PR allows for loading systems not listed by `ql:system-list`, e.g. the ones from `local-projects`.