### PR TITLE
List local systems in systems available for loading.

### DIFF
--- a/sly-quicklisp.el
+++ b/sly-quicklisp.el
@@ -5,7 +5,7 @@
 ;; Keywords: languages, lisp, sly
 ;; Package-Requires: ((sly "1.0.0-beta2"))
 ;; Author: João Távora <joaotavora@gmail.com>
-;; 
+;;
 ;; Copyright (C) 2015 João Távora
 ;;
 ;; This file is free software; you can redistribute it and/or modify
@@ -28,7 +28,7 @@
 ;; install.
 ;;
 ;; See README.md
-;; 
+;;
 ;;; Code:
 
 (require 'sly)
@@ -101,4 +101,3 @@ in `sly-editing-mode-hook', i.e. lisp files."
 
 (provide 'sly-quicklisp)
 ;;; sly-quicklisp.el ends here
-

--- a/slynk-quicklisp.lisp
+++ b/slynk-quicklisp.lisp
@@ -11,6 +11,6 @@
   (mapcar #'ql-dist:version (ql-dist:enabled-dists)))
 
 (defslyfun available-system-names ()
-  (cl:mapcar 'ql-dist:name (ql:system-list)))
+  (append (ql:list-local-systems) (cl:mapcar 'ql-dist:name (ql:system-list))))
 
 (provide 'slynk-quicklisp)


### PR DESCRIPTION
The procedure `available-system-names` currently doesn't list registered local systems. Changes herein merge the list of local systems with list of systems available from dists to make that easy.