### PR TITLE
Replace sly-completing-read with completing-read

### DIFF
--- a/sly-quicklisp.el
+++ b/sly-quicklisp.el
@@ -61,20 +61,18 @@ in `sly-editing-mode-hook', i.e. lisp files."
 (define-minor-mode sly-quicklisp-mode
   "A minor mode active when the contrib is active."
   :group 'sly
+  :keymap nil
   (cond (sly-quicklisp-mode
          (add-to-list 'sly-extra-mode-line-constructs
                       'sly-quicklisp--mode-line-construct
-                      t))
+                      t)
+         (define-key sly-prefix-map (kbd "C-d C-q") #'sly-quickload))
         (t
          (setq sly-extra-mode-line-constructs
                (delq 'sly-quicklisp--mode-line-construct
-                     sly-extra-mode-line-constructs)))))
-
-(defvar sly-quicklisp-map
-  (let ((map (make-sparse-keymap)))
-    (define-key sly-prefix-map (kbd "C-d C-q") 'sly-quickload)
-    map)
-  "A keymap accompanying `sly-quicklisp-mode'.")
+                     sly-extra-mode-line-constructs))
+         (when (eq (lookup-key sly-prefix-map (kbd "C-d C-q")) #'sly-quickload)
+           (define-key sly-prefix-map (kbd "C-d C-q") nil)))))
 
 (defun sly-quicklisp--mode-line-construct ()
   "A little pretty indicator in the mode-line"

--- a/sly-quicklisp.el
+++ b/sly-quicklisp.el
@@ -60,7 +60,7 @@ in `sly-editing-mode-hook', i.e. lisp files."
 
 (define-minor-mode sly-quicklisp-mode
   "A minor mode active when the contrib is active."
-  nil nil nil
+  :group 'sly
   (cond (sly-quicklisp-mode
          (add-to-list 'sly-extra-mode-line-constructs
                       'sly-quicklisp--mode-line-construct

--- a/sly-quicklisp.el
+++ b/sly-quicklisp.el
@@ -47,11 +47,11 @@ in `sly-editing-mode-hook', i.e. lisp files."
 (defun sly-quickload (system)
   "Interactive command made available in lisp-editing files."
   (interactive
-   (list (sly-completing-read "QL system? "
-                              (sly-eval
-                               '(slynk-quicklisp:available-system-names))
-                              nil
-                              nil)))
+   (list (completing-read "QL system? "
+                          (sly-eval
+                           '(slynk-quicklisp:available-system-names))
+                          nil
+                          nil)))
   (sly-eval-async `(slynk-quicklisp:quickload ,system)
     (lambda (retval)
       (setq sly-quicklisp--enabled-dists retval)


### PR DESCRIPTION
Also made a few small changes to `sly-quicklisp-mode`, but the last commit here seems suboptimal and there might be a better approach